### PR TITLE
Fixes 'projects' object definition at Online Resume Project

### DIFF
--- a/Front End/Online Resume Project.md
+++ b/Front End/Online Resume Project.md
@@ -128,7 +128,7 @@ The resume has four distinct sections: work, education, projects and a header wi
                   dates: string (works with a hyphen between them)
                   description: string
                   images: array with string urls
-                  display: function
+            display: function
 
 
 2. Iterate through each javaScript object and append its information to index.html in the correct section.


### PR DESCRIPTION
As presented at [Online Resume rubrics](https://review.udacity.com/#!/rubrics/13/view), "display" is a property of "projects". Before this fix, the file presents "display" as a property of projects.projects.